### PR TITLE
Update Elytra Slot mod id

### DIFF
--- a/forge-1.19/src/main/java/com/rejahtavi/betterflight/BetterFlight.java
+++ b/forge-1.19/src/main/java/com/rejahtavi/betterflight/BetterFlight.java
@@ -96,7 +96,7 @@ public class BetterFlight {
 
     @SubscribeEvent
     public void onLoadCompleteEvent(FMLLoadCompleteEvent event) {
-        if ((ModList.get().isLoaded("curiouselytra")
+        if ((ModList.get().isLoaded("elytraslot")
                 && ModList.get().isLoaded("curios"))) {
             isCuriousElytraLoaded = true;
         }


### PR DESCRIPTION
The Elytra Slot mod ([Curse Forge](https://www.curseforge.com/minecraft/mc-mods/elytra-slot)) ([github](https://github.com/illusivesoulworks/elytraslot)) changed their forge `mod_id` when they upgraded to 1.19. It used to be `curiouselytra`, but now it is `elytraslot` (see [here](https://github.com/illusivesoulworks/elytraslot/blob/aa1894911c545b91e49be1b2ded7504bfd5b9ef7/gradle.properties#L40)).

This way of manually checking seems fragile to me, and I don't think this will fix compatibility with [colytra](https://www.curseforge.com/minecraft/mc-mods/colytra). I'm also not sure if you would need to do a minor version bump. In any case, this (hacky) PR fixes compatibility with the elytra slot mod.

Tested with: 
Minecraft 1.19.2
Forge 43.1.47
curios-forge-1.19.2-5.1.1.0.jar
elytraslot-forge-6.0.0+1.19.2.jar
~100 other mods